### PR TITLE
Add instructions for making JavaDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ Can be built with [Maven 2.2.x](http://maven.apache.org) (or later?) by using th
 or, to install into your local Maven repository:
 
     mvn install
+    
+You may also wish to build API Documentation:
 
+    mvn javadoc:javadoc
 
 Authors
 -------

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Maven users should add the library using the following dependency:
       <version>1.3.0</version>
     </dependency>
 
+(lesscss-java is in the Maven Central repository.)
+
 Non-Maven users should download the latest version and add it to the project's classpath. Also the following dependencies are required:
 
 + <a href="http://commons.apache.org/io/">Apache Commons IO 2.1</a>
@@ -50,6 +52,18 @@ Support
 -------
 
 Have a question, or found an issue? Just create a issue: https://github.com/marceloverdijk/lesscss-java/issues
+
+
+Building From Source
+--------------------
+
+Can be built with [Maven 2.2.x](http://maven.apache.org) (or later?) by using the following commands:
+
+    mvn package
+
+or, to install into your local Maven repository:
+
+    mvn install
 
 
 Authors


### PR DESCRIPTION
Add instructions for making the JavaDocs (my 'mvn' is a little rusty, so it's just nice to have this stuff in the README)
