### PR TITLE
Match `*.less` instead of just `*less` when checking imports

### DIFF
--- a/src/main/java/org/lesscss/LessSource.java
+++ b/src/main/java/org/lesscss/LessSource.java
@@ -139,7 +139,7 @@ public class LessSource {
         Matcher importMatcher = IMPORT_PATTERN.matcher(normalizedContent);
         while (importMatcher.find()) {
             String importedFile = importMatcher.group(2);
-            importedFile = importedFile.matches(".*(le?|c)ss$") ? importedFile : importedFile + ".less";
+            importedFile = importedFile.matches(".*\\.(le?|c)ss$") ? importedFile : importedFile + ".less";
             boolean css = importedFile.matches(".*css$");
             if (!css) {
                     LessSource importedLessSource = new LessSource(new File(file.getParentFile(), importedFile));

--- a/src/test/java/integration/ImportIT.java
+++ b/src/test/java/integration/ImportIT.java
@@ -22,4 +22,9 @@ public class ImportIT extends AbstractCompileIT {
     public void testImport() throws Exception {
         testCompile(toFile("import/less/import.less"), toFile("import/css/import.css"));
     }
+
+    @Test
+    public void testImportEndsInLess() throws Exception {
+        testCompile(toFile("import/endsinless/less/import.less"), toFile("import/endsinless/css/import.css"));
+    }
 }

--- a/src/test/resources/import/endsinless/css/import.css
+++ b/src/test/resources/import/endsinless/css/import.css
@@ -1,0 +1,3 @@
+iendinless {
+  color: blue;
+}

--- a/src/test/resources/import/endsinless/less/iendinless.less
+++ b/src/test/resources/import/endsinless/less/iendinless.less
@@ -1,0 +1,3 @@
+iendinless {
+    color: blue;
+}

--- a/src/test/resources/import/endsinless/less/import.less
+++ b/src/test/resources/import/endsinless/less/import.less
@@ -1,0 +1,1 @@
+@import "iendinless";


### PR DESCRIPTION
This was preventing the implicit `.less` to be added when the import name ended with _less_.

This fixes marceloverdijk/lesscss-java#4
