### PR TITLE
send envjs output to commons logging rather than system.out

### DIFF
--- a/src/main/resources/META-INF/env.rhino.js
+++ b/src/main/resources/META-INF/env.rhino.js
@@ -1,3 +1,8 @@
+// Override the print function so that the messages go to commons logging
+print = function(message) {
+    Packages.org.apache.commons.logging.LogFactory.getLog('rhino').debug(message);
+};
+
 /*
  * Envjs core-env.1.2.13
  * Pure JavaScript Browser Environment


### PR DESCRIPTION
This way, the output can still be captured if desired, but user at least has a chance to suppress it.  When Envjs 1.3 comes out, a more sophisticated approach hooking into their new logging system would probably be better.
