### PR TITLE
Included dependencies can conflict with other versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
     
     <dependencies>
         <dependency>
+            <groupId>org.mozilla</groupId>
+            <artifactId>rhino</artifactId>
+            <version>1.7R4</version>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>
@@ -32,15 +37,16 @@
             <version>1.1.1</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.10</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.1</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -65,11 +71,6 @@
             <artifactId>concurrentunit</artifactId>
             <version>0.3.0</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mozilla</groupId>
-            <artifactId>rhino</artifactId>
-            <version>1.7R4</version>
         </dependency>
     </dependencies>
     
@@ -149,7 +150,34 @@
                             <version>1.0</version>
                         </signature>
                 </configuration>
-                </plugin>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>1.7.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons</pattern>
+                                    <shadedPattern>internaldeps.org.apache.commons</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.mozilla</pattern>
+                                    <shadedPattern>internaldeps.org.mozilla</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>deps</shadedClassifierName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     

--- a/pom.xml
+++ b/pom.xml
@@ -162,16 +162,19 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>commons-logging:commons-logging</exclude>
+                                    <exclude>org.mozilla:rhino</exclude>
+                                </excludes>
+                            </artifactSet>
                             <relocations>
                                 <relocation>
-                                    <pattern>org.apache.commons</pattern>
-                                    <shadedPattern>internaldeps.org.apache.commons</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.mozilla</pattern>
-                                    <shadedPattern>internaldeps.org.mozilla</shadedPattern>
+                                    <pattern>org.apache.commons.io</pattern>
+                                    <shadedPattern>internaldeps.org.apache.commons.io</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <minimizeJar>true</minimizeJar>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>deps</shadedClassifierName>
                         </configuration>


### PR DESCRIPTION
Including this library in my project introduced some dependencies that I would have preferred not to have. Using the maven shade plugin, we can inline these dependencies into a `-dep` jar, so the commons-io dependency doesn't leak out into the parent project.

I was unable to inline Rhino, as `env.rhino.js` has an explicit dependency on Rhino (line #1339, `Packages.org.mozilla.javascript.Context.getCurrentContext()`), and the shade plugin doesn't seem to be able to rewrite resource files.

Normal users can continue to use the existing artifact, but those who want only one dependency can use the `-dep` artifact.
