### PR TITLE
Add pluggable logging interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.1.1</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/org/lesscss/logger/CommonsLogger.java
+++ b/src/main/java/org/lesscss/logger/CommonsLogger.java
@@ -1,0 +1,25 @@
+package org.lesscss.logger;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class CommonsLogger implements Logger {
+
+    private final Log log;
+
+    public CommonsLogger(Class<?> loggingClass) {
+        log = LogFactory.getLog(loggingClass);
+    }
+
+    public void debug(Object message) {
+        log.debug(message);
+    }
+
+    public void error(Object message) {
+        log.error(message);
+    }
+
+    public void error(Object message, Throwable exception) {
+        log.error(message, exception);
+    }
+}

--- a/src/main/java/org/lesscss/logger/LastMessageLogger.java
+++ b/src/main/java/org/lesscss/logger/LastMessageLogger.java
@@ -1,0 +1,32 @@
+package org.lesscss.logger;
+
+public class LastMessageLogger implements Logger {
+    private String lastDebug;
+    private String lastError;
+    private Throwable lastException;
+
+    public void debug(Object message) {
+        lastDebug = message.toString();
+    }
+
+    public void error(Object message) {
+        lastError = message.toString();
+    }
+
+    public void error(Object message, Throwable exception) {
+        error(message);
+        lastException = exception;
+    }
+
+    public String lastDebug() {
+        return lastDebug;
+    }
+
+    public String lastError() {
+        return lastError;
+    }
+
+    public Throwable lastException() {
+        return lastException;
+    }
+}

--- a/src/main/java/org/lesscss/logger/Logger.java
+++ b/src/main/java/org/lesscss/logger/Logger.java
@@ -1,0 +1,7 @@
+package org.lesscss.logger;
+
+public interface Logger {
+    void debug(Object message);
+    void error(Object message);
+    void error(Object message, Throwable exception);
+}

--- a/src/main/java/org/lesscss/logger/StdLogger.java
+++ b/src/main/java/org/lesscss/logger/StdLogger.java
@@ -1,0 +1,15 @@
+package org.lesscss.logger;
+
+public class StdLogger implements Logger {
+    public void debug(Object message) {
+        System.out.println(message.toString());
+    }
+
+    public void error(Object message) {
+        System.err.println(message.toString());
+    }
+
+    public void error(Object message, Throwable exception) {
+        System.err.println(String.format("%s: %s", message, exception));
+    }
+}

--- a/src/main/resources/META-INF/env.rhino.js
+++ b/src/main/resources/META-INF/env.rhino.js
@@ -1,6 +1,6 @@
-// Override the print function so that the messages go to commons logging
+// Override the print function so that the messages go to the configured logger
 print = function(message) {
-    Packages.org.apache.commons.logging.LogFactory.getLog('rhino').debug(message);
+    logger.debug(message);
 };
 
 /*

--- a/src/test/java/org/lesscss/LessCompilerTest.java
+++ b/src/test/java/org/lesscss/LessCompilerTest.java
@@ -14,8 +14,7 @@
  */
 package org.lesscss;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -38,6 +37,8 @@ import org.apache.commons.logging.Log;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.lesscss.logger.LastMessageLogger;
+import org.lesscss.logger.Logger;
 import org.mockito.Mock;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
@@ -59,7 +60,7 @@ public class LessCompilerTest {
     
     private LessCompiler lessCompiler;
     
-    @Mock private Log log;
+    private LastMessageLogger logger = new LastMessageLogger();
     
     @Mock private Context cx;
     @Mock private Global global;
@@ -87,10 +88,7 @@ public class LessCompilerTest {
     
     @Before
     public void setUp() throws Exception {
-        lessCompiler = new LessCompiler();
-        
-        when(log.isDebugEnabled()).thenReturn(false);
-        FieldUtils.writeField(lessCompiler, "log", log, true);
+        lessCompiler = new LessCompiler(logger);
     }
     
     @Test
@@ -201,7 +199,7 @@ public class LessCompilerTest {
         
         verify(envJsFile).openConnection();
         
-        verify(log).error(anyString());
+        assertNotNull(logger.lastError());
     }
     
     @Test


### PR DESCRIPTION
In pull request #8 commons logging was added to stop messages spamming stdout. On a project that doesn't have commons-logging, this introduces an unwanted dependency.

This patch moves the logging behind an interface, which means individual projects can choose their desired logging strategy. By default the existing commons-logging method is used, but this can be changed by calling the `LessCompiler` constructor with a different `Logger`.

Three different `Logger`s are provided:
- A logger that delegates to commons-logging: `CommonsLogger` (default)
- A logger that prints to stdout and stderr: `StdLogger`
- A logger that stores the last message in memory, suitable for a test: `LastMessageLogger`
