### PR TITLE
Logging: replace required Commons Logging with optional SLF4J (fallback to java util logging)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Non-Maven users should download the latest version and add it to the project's c
 
 + <a href="http://commons.apache.org/io/">Apache Commons IO 2.4</a>
 + <a href="http://commons.apache.org/lang/">Apache Commons Lang 3.1</a>
-+ <a href="http://commons.apache.org/logging/">Apache Commons Logging 1.1.1</a>
 + <a href="http://www.mozilla.org/rhino/">Rhino: JavaScript for Java 1.7R4</a>
 
+If [SLF4J](http://www.slf4j.org/) is present in the classpath, it will be used for logging.
 
 Compatibility
 -------------

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,6 @@
             <version>2.4</version>
         </dependency>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.10</version>
@@ -70,6 +65,18 @@
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>
             <version>1.7R4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.2</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.2</version>
+            <scope>testRuntime</scope>
         </dependency>
     </dependencies>
     

--- a/src/main/java/org/lesscss/LessCompiler.java
+++ b/src/main/java/org/lesscss/LessCompiler.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.lesscss.logging.LessLogger;
+import org.lesscss.logging.LessLoggerFactory;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
 import org.mozilla.javascript.JavaScriptException;
@@ -59,9 +59,9 @@ import org.mozilla.javascript.tools.shell.Global;
 public class LessCompiler {
 
     private static final String COMPILE_STRING = "function doIt(input, compress) { var result; var parser = new less.Parser(); parser.parse(input, function(e, tree) { if (e instanceof Object) { throw e; } ; result = tree.toCSS({compress: compress}); }); return result; }";
-    
-    private static final Log log = LogFactory.getLog(LessCompiler.class);
-    
+
+    private static final LessLogger logger = LessLoggerFactory.getLogger(LessCompiler.class);
+
     private URL envJs = LessCompiler.class.getClassLoader().getResource("META-INF/env.rhino.js");
     private URL lessJs = LessCompiler.class.getClassLoader().getResource("META-INF/less.js");
     private List<URL> customJs = Collections.emptyList();
@@ -221,6 +221,7 @@ public class LessCompiler {
 	        global.init(cx); 
 	        
 	        scope = cx.initStandardObjects(global);
+            scope.put("logger", scope, Context.toObject(logger, scope));
 	        
 	        List<URL> jsUrls = new ArrayList<URL>(2 + customJs.size());
 	        jsUrls.add(envJs);
@@ -239,14 +240,14 @@ public class LessCompiler {
         }
         catch (Exception e) {
             String message = "Failed to initialize LESS compiler.";
-            log.error(message, e);
+            logger.error(message, e);
             throw new IllegalStateException(message, e);
         }finally{
         	Context.exit();
         }
         
-        if (log.isDebugEnabled()) {
-            log.debug("Finished initialization of LESS compiler in " + (System.currentTimeMillis() - start) + " ms.");
+        if (logger.isDebugEnabled()) {
+            logger.debug("Finished initialization of LESS compiler in " + (System.currentTimeMillis() - start) + " ms.");
         }
     }
     
@@ -269,8 +270,8 @@ public class LessCompiler {
         	Context cx = Context.enter();
             Object result = doIt.call(cx, scope, null, new Object[]{input, compress});
             
-            if (log.isDebugEnabled()) {
-                log.debug("Finished compilation of LESS source in " + (System.currentTimeMillis() - start) + " ms.");
+            if (logger.isDebugEnabled()) {
+                logger.debug("Finished compilation of LESS source in " + (System.currentTimeMillis() - start) + " ms.");
             }
             
             return result.toString();

--- a/src/main/java/org/lesscss/logging/JULILessLoggerProvider.java
+++ b/src/main/java/org/lesscss/logging/JULILessLoggerProvider.java
@@ -1,0 +1,38 @@
+package org.lesscss.logging;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class JULILessLoggerProvider implements LessLoggerProvider {
+    public LessLogger getLogger(Class<?> clazz) {
+        return new JULILessLogger(Logger.getLogger(clazz.getName()));
+    }
+
+    private static class JULILessLogger implements LessLogger {
+        private final Logger logger;
+
+        private JULILessLogger(Logger logger) {
+            this.logger = logger;
+        }
+
+        public boolean isDebugEnabled() {
+            return logger.isLoggable(Level.FINE);
+        }
+
+        public boolean isInfoEnabled() {
+            return logger.isLoggable(Level.INFO);
+        }
+
+        public void debug(String msg) {
+            logger.fine(msg);
+        }
+
+        public void info(String msg) {
+            logger.info(msg);
+        }
+
+        public void error(String msg, Throwable t) {
+            logger.log(Level.SEVERE, msg, t);
+        }
+    }
+}

--- a/src/main/java/org/lesscss/logging/LessLogger.java
+++ b/src/main/java/org/lesscss/logging/LessLogger.java
@@ -1,0 +1,13 @@
+package org.lesscss.logging;
+
+public interface LessLogger {
+    boolean isDebugEnabled();
+
+    boolean isInfoEnabled();
+
+    void debug(String msg);
+
+    void info(String msg);
+
+    void error(String msg, Throwable t);
+}

--- a/src/main/java/org/lesscss/logging/LessLoggerFactory.java
+++ b/src/main/java/org/lesscss/logging/LessLoggerFactory.java
@@ -1,0 +1,19 @@
+package org.lesscss.logging;
+
+public class LessLoggerFactory {
+    private static LessLoggerFactory instance = new LessLoggerFactory();
+    private LessLoggerProvider loggerProvider;
+
+    private LessLoggerFactory() {
+        try {
+            Class.forName("org.slf4j.Logger");
+            loggerProvider = new SLF4JLessLoggerProvider();
+        } catch(ClassNotFoundException ex) {
+            loggerProvider = new JULILessLoggerProvider();
+        }
+    }
+
+    public static LessLogger getLogger(Class<?> clazz) {
+        return instance.loggerProvider.getLogger(clazz);
+    }
+}

--- a/src/main/java/org/lesscss/logging/LessLoggerProvider.java
+++ b/src/main/java/org/lesscss/logging/LessLoggerProvider.java
@@ -1,0 +1,5 @@
+package org.lesscss.logging;
+
+interface LessLoggerProvider {
+    LessLogger getLogger(Class<?> clazz);
+}

--- a/src/main/java/org/lesscss/logging/SLF4JLessLoggerProvider.java
+++ b/src/main/java/org/lesscss/logging/SLF4JLessLoggerProvider.java
@@ -1,0 +1,35 @@
+package org.lesscss.logging;
+
+class SLF4JLessLoggerProvider implements LessLoggerProvider {
+    public LessLogger getLogger(Class<?> clazz) {
+        return new SLF4JLessLogger(org.slf4j.LoggerFactory.getLogger(clazz));
+    }
+
+    private static class SLF4JLessLogger implements LessLogger {
+        private final org.slf4j.Logger logger;
+
+        private SLF4JLessLogger(org.slf4j.Logger logger) {
+            this.logger = logger;
+        }
+
+        public boolean isDebugEnabled() {
+            return logger.isDebugEnabled();
+        }
+
+        public boolean isInfoEnabled() {
+            return logger.isInfoEnabled();
+        }
+
+        public void debug(String msg) {
+            logger.debug(msg);
+        }
+
+        public void info(String msg) {
+            logger.info(msg);
+        }
+
+        public void error(String msg, Throwable t) {
+            logger.error(msg, t);
+        }
+    }
+}

--- a/src/main/resources/META-INF/env.rhino.js
+++ b/src/main/resources/META-INF/env.rhino.js
@@ -1,6 +1,6 @@
-// Override the print function so that the messages go to commons logging
+// Override the print function so that the messages go to the configured loggerthe configured logger
 print = function(message) {
-    Packages.org.apache.commons.logging.LogFactory.getLog('rhino').debug(message);
+    logger.debug(message);
 };
 
 /*

--- a/src/test/java/org/lesscss/LessCompilerTest.java
+++ b/src/test/java/org/lesscss/LessCompilerTest.java
@@ -16,6 +16,7 @@ package org.lesscss;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -34,10 +35,10 @@ import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.commons.logging.Log;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.lesscss.logging.LessLogger;
 import org.mockito.Mock;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.Function;
@@ -59,7 +60,7 @@ public class LessCompilerTest {
     
     private LessCompiler lessCompiler;
     
-    @Mock private Log log;
+    @Mock private LessLogger logger;
     
     @Mock private Context cx;
     @Mock private Global global;
@@ -89,8 +90,8 @@ public class LessCompilerTest {
     public void setUp() throws Exception {
         lessCompiler = new LessCompiler();
         
-        when(log.isDebugEnabled()).thenReturn(false);
-        FieldUtils.writeField(lessCompiler, "log", log, true);
+        when(logger.isDebugEnabled()).thenReturn(false);
+        FieldUtils.writeField(lessCompiler, "logger", logger, true);
     }
     
     @Test
@@ -201,7 +202,7 @@ public class LessCompilerTest {
         
         verify(envJsFile).openConnection();
         
-        verify(log).error(anyString());
+        verify(logger).error(anyString(), (Throwable) anyObject());
     }
     
     @Test


### PR DESCRIPTION
This patch was inspired by @spmiller's work on a pluggable logging interface.  This patch caters to two main audiences: those two don't want any extraneous dependencies (by removing the need for commons logging) and those who want to be able to redirect and/or suppress logging via standard logging configuration (when SLF4J and a binding are provided).

https://github.com/marceloverdijk/lesscss-java/pull/16
