### PR TITLE
Add the ability to specify the input encoding for the LessCompiler.

### DIFF
--- a/src/main/java/org/lesscss/LessCompiler.java
+++ b/src/main/java/org/lesscss/LessCompiler.java
@@ -21,6 +21,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.lesscss.logging.LessLogger;
 import org.lesscss.logging.LessLoggerFactory;
@@ -66,7 +68,8 @@ public class LessCompiler {
     private URL lessJs = LessCompiler.class.getClassLoader().getResource("META-INF/less.js");
     private List<URL> customJs = Collections.emptyList();
     private boolean compress = false;
-    private String encoding = null;
+    private String outputEncoding = null;
+    private String inputEncoding = null;
     
     private Function doIt;
     
@@ -113,7 +116,7 @@ public class LessCompiler {
      * Sets the LESS JavaScript file used by the compiler.
      * Must be set before {@link #init()} is called.
      * 
-     * @param The LESS JavaScript file used by the compiler.
+     * @param lessJs The LESS JavaScript file used by the compiler.
      */
     public synchronized void setLessJs(URL lessJs) {
         if (scope != null) {
@@ -181,12 +184,12 @@ public class LessCompiler {
     }
     
     /**
-     * Returns the character encoding used by the compiler when writing the output <code>File</code>.
+     * Returns the character outputEncoding used by the compiler when writing the output <code>File</code>.
      * 
-     * @return The character encoding used by the compiler when writing the output <code>File</code>.
+     * @return The character outputEncoding used by the compiler when writing the output <code>File</code>.
      */
-    public String getEncoding() {
-        return encoding;
+    public String getOutputEncoding() {
+        return outputEncoding;
     }
     
     /**
@@ -194,13 +197,36 @@ public class LessCompiler {
      * If not set the platform default will be used.
      * Must be set before {@link #init()} is called.
      * 
-     * @param The character encoding used by the compiler when writing the output <code>File</code>.
+     * @param outputEncoding The character encoding used by the compiler when writing the output <code>File</code>.
      */
-    public synchronized void setEncoding(String encoding) {
+    public synchronized void setOutputEncoding(String outputEncoding) {
         if (scope != null) {
             throw new IllegalStateException("This method can only be called before init()");
         }
-        this.encoding = encoding;
+        this.outputEncoding = outputEncoding;
+    }
+
+    /**
+     * Returns the character encoding used by the compiler when reading the input <code>File</code>.
+     *
+     * @return The character encoding used by the compiler when reading the input <code>File</code>.
+     */
+    public String getInputEncoding() {
+        return inputEncoding;
+    }
+
+    /**
+     * Sets the character encoding used by the compiler when reading the input <code>File</code>.
+     * If not set the platform default will be used.
+     * Must be set before {@link #init()} is called.
+     *
+     * @param inputEncoding The character encoding used by the compiler when reading the input <code>File</code>.
+     */
+    public synchronized void setInputEncoding(String inputEncoding) {
+        if (scope != null) {
+            throw new IllegalStateException("This method can only be called before init()");
+        }
+        this.inputEncoding = inputEncoding;
     }
     
     /**
@@ -298,7 +324,7 @@ public class LessCompiler {
      * @throws IOException If the LESS file cannot be read.
      */
     public String compile(File input) throws IOException, LessException {
-        LessSource lessSource = new LessSource(input);
+        LessSource lessSource = new LessSource(input, Charsets.toCharset(inputEncoding));
         return compile(lessSource);
     }
     
@@ -322,7 +348,7 @@ public class LessCompiler {
      * @throws IOException If the LESS file cannot be read or the output file cannot be written.
      */
     public void compile(File input, File output, boolean force) throws IOException, LessException {
-        LessSource lessSource = new LessSource(input);
+        LessSource lessSource = new LessSource(input, Charsets.toCharset(inputEncoding));
         compile(lessSource, output, force);
     }
     
@@ -358,7 +384,7 @@ public class LessCompiler {
     public void compile(LessSource input, File output, boolean force) throws IOException, LessException {
         if (force || !output.exists() || output.lastModified() < input.getLastModifiedIncludingImports()) {
             String data = compile(input);
-            FileUtils.writeStringToFile(output, data, encoding);
+            FileUtils.writeStringToFile(output, data, outputEncoding);
         }
     }
 }

--- a/src/main/java/org/lesscss/LessSource.java
+++ b/src/main/java/org/lesscss/LessSource.java
@@ -43,6 +43,7 @@ public class LessSource {
     private String content;
     private String normalizedContent;
     private Map<String, LessSource> imports = new LinkedHashMap<String, LessSource>();
+    private Charset inputCharset;
     
     /**
      * Constructs a new <code>LessSource</code>.
@@ -76,10 +77,14 @@ public class LessSource {
         if (file == null) {
             throw new IllegalArgumentException("File must not be null.");
         }
+        if(charset == null) {
+            throw new IllegalArgumentException("Charset must not be null");
+        }
         if (!file.exists()) {
             throw new FileNotFoundException("File " + file.getAbsolutePath() + " not found.");
         }
         this.file = file;
+        this.inputCharset = charset;
         this.content = this.normalizedContent = FileUtils.readFileToString(file, charset);
         resolveImports();
     }
@@ -163,7 +168,7 @@ public class LessSource {
             importedFile = importedFile.matches(".*\\.(le?|c)ss$") ? importedFile : importedFile + ".less";
             boolean css = importedFile.matches(".*css$");
             if (!css) {
-                    LessSource importedLessSource = new LessSource(new File(file.getParentFile(), importedFile));
+                    LessSource importedLessSource = new LessSource(new File(file.getParentFile(), importedFile), inputCharset);
                     imports.put(importedFile, importedLessSource);
                     normalizedContent = normalizedContent.substring(0, importMatcher.start()) + importedLessSource.getNormalizedContent() + normalizedContent.substring(importMatcher.end());
                     importMatcher = IMPORT_PATTERN.matcher(normalizedContent);

--- a/src/test/java/org/lesscss/LessCompilerTest.java
+++ b/src/test/java/org/lesscss/LessCompilerTest.java
@@ -33,6 +33,8 @@ import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.Before;
@@ -47,10 +49,6 @@ import org.mozilla.javascript.Scriptable;
 import org.mozilla.javascript.tools.shell.Global;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import org.lesscss.LessCompiler;
-import org.lesscss.LessException;
-import org.lesscss.LessSource;
 
 @PrepareForTest({Context.class, FileUtils.class, LessCompiler.class})
 @RunWith(PowerMockRunner.class)
@@ -275,14 +273,14 @@ public class LessCompilerTest {
         FieldUtils.writeField(lessCompiler, "scope", scope, true);
         FieldUtils.writeField(lessCompiler, "doIt", doIt, true);
         
-        whenNew(LessSource.class).withArguments(inputFile).thenReturn(lessSource);
+        whenNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String) null)).thenReturn(lessSource);
         when(lessSource.getNormalizedContent()).thenReturn(less);
         
         when(doIt.call(cx, scope, null, new Object[]{less, false})).thenReturn(css);
         
         assertEquals(css, lessCompiler.compile(inputFile));
         
-        verifyNew(LessSource.class).withArguments(inputFile);
+        verifyNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null));
         verify(lessSource).getNormalizedContent();
 
         verify(doIt).call(cx, scope, null, new Object[]{less, false});
@@ -294,8 +292,8 @@ public class LessCompilerTest {
         when(Context.enter()).thenReturn(cx);
         FieldUtils.writeField(lessCompiler, "scope", scope, true);
         FieldUtils.writeField(lessCompiler, "doIt", doIt, true);
-        
-        whenNew(LessSource.class).withArguments(inputFile).thenReturn(lessSource);
+
+        whenNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null)).thenReturn(lessSource);
         when(lessSource.getNormalizedContent()).thenReturn(less);
         
         when(doIt.call(cx, scope, null, new Object[]{less, false})).thenReturn(css);
@@ -303,8 +301,8 @@ public class LessCompilerTest {
         mockStatic(FileUtils.class);
         
         lessCompiler.compile(inputFile, outputFile);
-        
-        verifyNew(LessSource.class).withArguments(inputFile);
+
+        verifyNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null));
         verify(lessSource).getNormalizedContent();
         
         verify(doIt).call(cx, scope, null, new Object[]{less, false});
@@ -319,8 +317,8 @@ public class LessCompilerTest {
         when(Context.enter()).thenReturn(cx);
         FieldUtils.writeField(lessCompiler, "scope", scope, true);
         FieldUtils.writeField(lessCompiler, "doIt", doIt, true);
-        
-        whenNew(LessSource.class).withArguments(inputFile).thenReturn(lessSource);
+
+        whenNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null)).thenReturn(lessSource);
         when(lessSource.getNormalizedContent()).thenReturn(less);
         
         when(doIt.call(cx, scope, null, new Object[]{less, false})).thenReturn(css);
@@ -328,8 +326,8 @@ public class LessCompilerTest {
         mockStatic(FileUtils.class);
         
         lessCompiler.compile(inputFile, outputFile, true);
-        
-        verifyNew(LessSource.class).withArguments(inputFile);
+
+        verifyNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null));
         verify(lessSource).getNormalizedContent();
         
         verify(doIt).call(cx, scope, null, new Object[]{less, false});
@@ -346,8 +344,8 @@ public class LessCompilerTest {
         FieldUtils.writeField(lessCompiler, "doIt", doIt, true);
         
         when(outputFile.exists()).thenReturn(false);
-        
-        whenNew(LessSource.class).withArguments(inputFile).thenReturn(lessSource);
+
+        whenNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null)).thenReturn(lessSource);
         when(lessSource.getNormalizedContent()).thenReturn(less);
         
         when(doIt.call(cx, scope, null, new Object[]{less, false})).thenReturn(css);
@@ -355,8 +353,8 @@ public class LessCompilerTest {
         mockStatic(FileUtils.class);
         
         lessCompiler.compile(inputFile, outputFile, false);
-        
-        verifyNew(LessSource.class).withArguments(inputFile);
+
+        verifyNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null));
         
         verify(outputFile).exists();
         
@@ -374,8 +372,8 @@ public class LessCompilerTest {
         when(Context.enter()).thenReturn(cx);
         FieldUtils.writeField(lessCompiler, "scope", scope, true);
         FieldUtils.writeField(lessCompiler, "doIt", doIt, true);
-        
-        whenNew(LessSource.class).withArguments(inputFile).thenReturn(lessSource);
+
+        whenNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null)).thenReturn(lessSource);
         
         when(outputFile.exists()).thenReturn(true);
         when(outputFile.lastModified()).thenReturn(1l);
@@ -388,8 +386,8 @@ public class LessCompilerTest {
         mockStatic(FileUtils.class);
         
         lessCompiler.compile(inputFile, outputFile, false);
-        
-        verifyNew(LessSource.class).withArguments(inputFile);
+
+        verifyNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null));
         
         verify(outputFile).exists();
         verify(outputFile).lastModified();
@@ -409,8 +407,8 @@ public class LessCompilerTest {
         when(Context.enter()).thenReturn(cx);
         FieldUtils.writeField(lessCompiler, "scope", scope, true);
         FieldUtils.writeField(lessCompiler, "doIt", doIt, true);
-        
-        whenNew(LessSource.class).withArguments(inputFile).thenReturn(lessSource);
+
+        whenNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null)).thenReturn(lessSource);
         
         when(outputFile.exists()).thenReturn(true);
         when(outputFile.lastModified()).thenReturn(2l);
@@ -418,8 +416,8 @@ public class LessCompilerTest {
         when(lessSource.getLastModifiedIncludingImports()).thenReturn(1l);
         
         lessCompiler.compile(inputFile, outputFile, false);
-        
-        verifyNew(LessSource.class).withArguments(inputFile);
+
+        verifyNew(LessSource.class).withArguments(inputFile, Charsets.toCharset((String)null));
         
         verify(outputFile).exists();
         verify(outputFile).lastModified();
@@ -601,11 +599,11 @@ public class LessCompilerTest {
     public void testEncoding() throws Exception {
         mockStatic(Context.class);
         when(Context.enter()).thenReturn(cx);
-        lessCompiler.setEncoding("utf-8");
+        lessCompiler.setOutputEncoding("utf-8");
         FieldUtils.writeField(lessCompiler, "scope", scope, true);
         FieldUtils.writeField(lessCompiler, "doIt", doIt, true);
         
-        whenNew(LessSource.class).withArguments(inputFile).thenReturn(lessSource);
+        whenNew(LessSource.class).withArguments(inputFile, Charsets.toCharset(lessCompiler.getInputEncoding())).thenReturn(lessSource);
         when(lessSource.getNormalizedContent()).thenReturn(less);
         
         when(doIt.call(cx, scope, null, new Object[]{less, false})).thenReturn(css);
@@ -614,7 +612,7 @@ public class LessCompilerTest {
         
         lessCompiler.compile(inputFile, outputFile);
         
-        verifyNew(LessSource.class).withArguments(inputFile);
+        verifyNew(LessSource.class).withArguments(inputFile, Charsets.toCharset(lessCompiler.getInputEncoding()));
         verify(lessSource).getNormalizedContent();
         
         verify(doIt).call(cx, scope, null, new Object[]{less, false});

--- a/src/test/java/org/lesscss/LessSourceTest.java
+++ b/src/test/java/org/lesscss/LessSourceTest.java
@@ -14,6 +14,7 @@
  */
 package org.lesscss;
 
+import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.Before;
@@ -75,7 +76,7 @@ public class LessSourceTest {
         assertEquals(0, lessSource.getImports().size());
         
         verifyStatic();
-        FileUtils.readFileToString(file);
+        FileUtils.readFileToString(file, Charset.defaultCharset());
     }
     
     @Test(expected = IllegalArgumentException.class)
@@ -140,7 +141,7 @@ public class LessSourceTest {
     private File mockFile(boolean fileExists, String content, String absolutePath) throws IOException {
         when(file.exists()).thenReturn(fileExists);
         mockStatic(FileUtils.class);
-        when(FileUtils.readFileToString(file)).thenReturn(content);
+        when(FileUtils.readFileToString(file, Charset.defaultCharset())).thenReturn(content);
         when(file.getAbsolutePath()).thenReturn(absolutePath);
         when(file.lastModified()).thenReturn(lastModified);
         when(file.getParent()).thenReturn("folder");


### PR DESCRIPTION
Defaults to the default encoding if not specified. This is useful when using LESS files that contain non-ASCII content such as those provided by font libraries such as Fontello, on a system whose default encoding is not UTF-8.
