### PR TITLE
import failed when closing brace is on same line

### DIFF
--- a/src/main/java/org/lesscss/LessSource.java
+++ b/src/main/java/org/lesscss/LessSource.java
@@ -37,7 +37,7 @@ public class LessSource {
     /**
      * The <code>Pattern</code> used to match imported files.
      */
-    private static final Pattern IMPORT_PATTERN = Pattern.compile("^(?!\\s*//\\s*)@import\\s+(url\\()?\\s*(\"|')(.+)\\s*(\"|')(\\))?\\s*;.*$", MULTILINE);
+    private static final Pattern IMPORT_PATTERN = Pattern.compile("^(?!\\s*//\\s*).*(@import\\s+(url\\()?\\s*(\"|')(.+)\\s*(\"|')(\\))?\\s*;).*$", MULTILINE);
 
     private File file;
     private String content;
@@ -159,13 +159,13 @@ public class LessSource {
     private void resolveImports() throws FileNotFoundException, IOException {
         Matcher importMatcher = IMPORT_PATTERN.matcher(normalizedContent);
         while (importMatcher.find()) {
-            String importedFile = importMatcher.group(3);
+            String importedFile = importMatcher.group(4);
             importedFile = importedFile.matches(".*\\.(le?|c)ss$") ? importedFile : importedFile + ".less";
             boolean css = importedFile.matches(".*css$");
             if (!css) {
                     LessSource importedLessSource = new LessSource(new File(file.getParentFile(), importedFile));
                     imports.put(importedFile, importedLessSource);
-                    normalizedContent = normalizedContent.substring(0, importMatcher.start()) + importedLessSource.getNormalizedContent() + normalizedContent.substring(importMatcher.end());
+                    normalizedContent = normalizedContent.substring(0, importMatcher.start(1)) + importedLessSource.getNormalizedContent() + normalizedContent.substring(importMatcher.end(1));
                     importMatcher = IMPORT_PATTERN.matcher(normalizedContent);
             }
         }

--- a/src/test/resources/import/css/import.css
+++ b/src/test/resources/import/css/import.css
@@ -7,3 +7,8 @@ import1b {
 import4 {
   color: blue;
 }
+@media screen {
+  import4 {
+    color: blue;
+  }
+}

--- a/src/test/resources/import/less/import.less
+++ b/src/test/resources/import/less/import.less
@@ -2,3 +2,5 @@
 //@import "import2.less";
 // @import "import3.less";
 @import "import4";
+
+@media screen { @import "import4"; }

--- a/src/test/resources/import/less/import_quotes.less
+++ b/src/test/resources/import/less/import_quotes.less
@@ -2,3 +2,5 @@
 //@import 'import2.less';
 // @import 'import3.less';
 @import "import4";
+
+@media screen { @import 'import4'; }


### PR DESCRIPTION
Hi,

I solved an issue with the complier when the import is closed on same line.

An example of syntax that causes the problem :
@media all and (min-width: 640px) { @import 'desktop-grid-style.less'; }

Stacktrace :
Error compiling LESS source
org.lesscss.LessException: Couldn't load undefineddesktop-grid-style.less (0)
at org.lesscss.LessCompiler.compile(LessCompiler.java:283)
at org.lesscss.LessCompiler.compile(LessCompiler.java:335)
at org.lesscss.LessCompiler.compile(LessCompiler.java:359)
at org.lesscss.mojo.CompileMojo.execute(CompileMojo.java:131)
