### PR TITLE
bug fix with absolute uri IMPORT

### DIFF
--- a/src/main/java/org/lesscss/FileResource.java
+++ b/src/main/java/org/lesscss/FileResource.java
@@ -7,59 +7,60 @@ import java.io.InputStream;
 
 /**
  * File based implementation of {@link Resource}.
- *
+ * 
  * @author Anton Pechinsky
  */
 public class FileResource implements Resource {
 
-    private File file;
+  private final File file;
 
-    private File sourceDirectory;
-    
-    
-    public FileResource(File file) {
-        if (file == null) {
-            throw new IllegalArgumentException("File must not be null!");
-        }
-        this.file = file;
-    }
+  private File sourceDirectory;
 
-    public FileResource(File sourceDirectory,File file) {
-      this(file);
-      this.sourceDirectory=sourceDirectory;
+  public FileResource(File file) {
+    if (file == null) {
+      throw new IllegalArgumentException("File must not be null!");
     }
-    public boolean exists() {
-        return file.exists();
-    }
+    this.file = file;
+  }
 
-    public InputStream getInputStream() throws IOException {
-        return new FileInputStream(file);
+  public FileResource(File sourceDirectory, File file) {
+    this(file);
+    if (sourceDirectory == null) {
+      throw new IllegalArgumentException("sourceDirectory must not be null!");
     }
+    this.sourceDirectory = sourceDirectory;
+  }
 
-    public long lastModified() {
-        return file.lastModified();
-    }
+  public boolean exists() {
+    return file.exists();
+  }
 
-    public Resource createRelative(String relativePath) {
-      
-      File relativeFile;
-      if (sourceDirectory != null && relativePath.startsWith("/"))
-      {
-        relativeFile = new File(sourceDirectory, relativePath);
-        return new FileResource(sourceDirectory, relativeFile);
-      }else
-      {
-         relativeFile = new File(file.getParentFile(), relativePath);
-         return new FileResource(relativeFile);
-      }
-    }
+  public InputStream getInputStream() throws IOException {
+    return new FileInputStream(file);
+  }
 
-    @Override
-    public String toString() {
-        return file.getAbsolutePath();
-    }
+  public long lastModified() {
+    return file.lastModified();
+  }
 
-    public String getName() {
-        return file.getAbsolutePath();
+  public Resource createRelative(String relativePath) {
+
+    File relativeFile;
+    if (sourceDirectory != null && relativePath.startsWith("/")) {
+      relativeFile = new File(sourceDirectory, relativePath);
+      return new FileResource(sourceDirectory, relativeFile);
+    } else {
+      relativeFile = new File(file.getParentFile(), relativePath);
+      return new FileResource(relativeFile);
     }
+  }
+
+  @Override
+  public String toString() {
+    return file.getAbsolutePath();
+  }
+
+  public String getName() {
+    return file.getAbsolutePath();
+  }
 }

--- a/src/main/java/org/lesscss/FileResource.java
+++ b/src/main/java/org/lesscss/FileResource.java
@@ -14,6 +14,9 @@ public class FileResource implements Resource {
 
     private File file;
 
+    private File sourceDirectory;
+    
+    
     public FileResource(File file) {
         if (file == null) {
             throw new IllegalArgumentException("File must not be null!");
@@ -21,6 +24,10 @@ public class FileResource implements Resource {
         this.file = file;
     }
 
+    public FileResource(File sourceDirectory,File file) {
+      this(file);
+      this.sourceDirectory=sourceDirectory;
+    }
     public boolean exists() {
         return file.exists();
     }
@@ -34,7 +41,15 @@ public class FileResource implements Resource {
     }
 
     public Resource createRelative(String relativePath) {
-        File relativeFile = new File(file.getParentFile(), relativePath);
+      
+      File relativeFile;
+      if (relativePath.startsWith("/"))
+      {
+        relativeFile = new File(sourceDirectory, relativePath);
+      }else
+      {
+         relativeFile = new File(file.getParentFile(), relativePath);
+      }
         return new FileResource(relativeFile);
     }
 

--- a/src/main/java/org/lesscss/FileResource.java
+++ b/src/main/java/org/lesscss/FileResource.java
@@ -46,11 +46,12 @@ public class FileResource implements Resource {
       if (sourceDirectory != null && relativePath.startsWith("/"))
       {
         relativeFile = new File(sourceDirectory, relativePath);
+        return new FileResource(sourceDirectory, relativeFile);
       }else
       {
          relativeFile = new File(file.getParentFile(), relativePath);
+         return new FileResource(relativeFile);
       }
-        return new FileResource(relativeFile);
     }
 
     @Override

--- a/src/main/java/org/lesscss/FileResource.java
+++ b/src/main/java/org/lesscss/FileResource.java
@@ -43,7 +43,7 @@ public class FileResource implements Resource {
     public Resource createRelative(String relativePath) {
       
       File relativeFile;
-      if (relativePath.startsWith("/"))
+      if (sourceDirectory != null && relativePath.startsWith("/"))
       {
         relativeFile = new File(sourceDirectory, relativePath);
       }else

--- a/src/main/java/org/lesscss/LessSource.java
+++ b/src/main/java/org/lesscss/LessSource.java
@@ -100,7 +100,11 @@ public class LessSource {
     public LessSource(File input) throws IOException {
         this( new FileResource(input) );
     }
-
+    
+    public LessSource(File sourceDirectory, File input) throws IOException {
+      this( new FileResource(sourceDirectory, input) );
+  }
+    
     private String loadResource(Resource resource, Charset charset) throws IOException {
         BOMInputStream inputStream = new BOMInputStream( resource.getInputStream() );
         try {


### PR DESCRIPTION
exemple :
@import "/bootstrap/less/bootstrap.less";

if the source file is not present into root directory.

the compilation fail :

[ERROR] D:\dev\billetel\IRIS_14.03\modules\lotus\src\main\webapp\bordel\less\sty
les.less [0:0]: Error compiling LESS source
java.io.FileNotFoundException: File D:\dev\billetel\IRIS_14.03\modules\lotus\src
\main\webapp\bordel\less\bootstrap\less\bootstrap.less not found.
        at org.lesscss.LessSource.<init>(LessSource.java:59)
        at org.lesscss.LessSource.resolveImports(LessSource.java:145)
        at org.lesscss.LessSource.<init>(LessSource.java:63)
        at org.lesscss.mojo.CompileMojo.execute(CompileMojo.java:123)
        at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(Default
BuildPluginManager.java:106)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor
.java:208)
        at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor
.java:153)

the file "bootstrap.less" is not in "D:\dev\billetel\IRIS_14.03\modules\lotus\src
\main\webapp\bordel\less\bootstrap\less\bootstrap.less" but into D:\dev\billetel\IRIS_14.03\modules\lotus\src
\main\webapp\bordel\bootstrap\less\bootstrap.less"
