### PR TITLE
fix shading of slf4j (#51)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,8 @@
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.mozilla:rhino</exclude>
+                                    <exclude>org.slf4j:slf4j-api</exclude>
+                                    <exclude>org.slf4j:slf4j-simple</exclude>
                                 </excludes>
                             </artifactSet>
                             <relocations>


### PR DESCRIPTION
The previous shading included slf4j-api and slf4j-simple in the shaded jar.
slf4j-simple was intended as a runtime dependency, and thus shouldn't have been included.
slf4j-api was intended as an optional non-shaded dependency, and thus shouldn't have been included.
