### PR TITLE
Reference import test

### DIFF
--- a/src/test/java/integration/ImportIT.java
+++ b/src/test/java/integration/ImportIT.java
@@ -39,4 +39,9 @@ public class ImportIT extends AbstractCompileIT {
     	// I would appreciate it if someone finds a fix for this test.
         testCompile(toFile("import/less/http_import.less"), toFile("import/css/http_import.css"));
     }
+    
+    @Test
+    public void testImportReference() throws Exception {
+        testCompile(toFile("import/less/import_reference.less"), toFile("import/css/import_reference.css"));
+    }    
 }

--- a/src/test/resources/import/css/import_reference.css
+++ b/src/test/resources/import/css/import_reference.css
@@ -1,0 +1,4 @@
+#header h1 {
+  font-weight: bold;
+  color: red;
+}

--- a/src/test/resources/import/less/import_reference.less
+++ b/src/test/resources/import/less/import_reference.less
@@ -1,0 +1,7 @@
+@import (reference) "reference.less";
+
+#header {
+    h1 {
+        &:extend(h1);
+    }
+}

--- a/src/test/resources/import/less/reference.less
+++ b/src/test/resources/import/less/reference.less
@@ -1,0 +1,4 @@
+h1 {
+    font-weight:bold;
+    color: red;
+}


### PR DESCRIPTION
In the previous versions import by reference was broken. Started to fix this but after adding the test found out it already was fixed. But since you can never have enough tests, here it is. 
